### PR TITLE
Remove call to mktemp for better determinism

### DIFF
--- a/static-stack2nix-builder/stack2nix-script.nix
+++ b/static-stack2nix-builder/stack2nix-script.nix
@@ -74,7 +74,9 @@
     set -eu -o pipefail
     export NIX_PATH=nixpkgs=${pkgs.path}
     export PATH=${pkgs.lib.concatStringsSep ":" add_to_PATH}:$PATH
-    OUT_DIR=$(mktemp --directory -t stack2nix-output-dir.XXXXXXXXXX)
+    OUT_DIR="/tmp/stack2nix-output-dir.424242424242"
+    rm -rf "${OUT_DIR}"
+    mkdir -p "${OUT_DIR}"
     set -x
     ${fixed_stack2nix}/bin/stack2nix "${stack-project-dir}" --stack-yaml "${stack-yaml}" --hackage-snapshot "${hackageSnapshot}" -o "$OUT_DIR/stack2nix-output.nix" "$@" 1>&2
     nix-store --add "$OUT_DIR/stack2nix-output.nix"


### PR DESCRIPTION
This is to make built outputs more deterministic.